### PR TITLE
fix(dissector): upgrade binary dissector to IEC 61162-450 Edition 2

### DIFF
--- a/maritime-modules/binarystream.lua
+++ b/maritime-modules/binarystream.lua
@@ -7,16 +7,17 @@ IEC_61162_450_PKTS = {}
 local binarystream = {}
 
 function binarystream:get_binary_stream(buffer, pinfo)
-    local msgtype = buffer(20,2):uint()
+    local msgtype = buffer(22,2):uint()
     local first_pack = nil
     local prev_pack = nil
     local next_pack = nil
 
     if msgtype == 1 then
-        local sourceid = buffer(8,6):string()
-        local blockid = buffer(22,4):uint()
-        local seqnum = buffer(26, 4):uint()
-        local maxseqnum = buffer(30,4):uint()
+        local sourceid = buffer(10,6):string()
+        local blockid = buffer(24,4):uint()
+        local seqnum = buffer(28, 4):uint()
+        local maxseqnum = buffer(32,4):uint()
+
         if IEC_61162_450_PKTS[sourceid] == nil then
             IEC_61162_450_PKTS[sourceid] = {}
             IEC_61162_450_PKTS[sourceid][blockid] = {}

--- a/maritime-modules/heuristic.lua
+++ b/maritime-modules/heuristic.lua
@@ -104,7 +104,7 @@ end
 
 local function iec_61162_450_binary_heuristic_checker(buffer, pinfo, tree)
     local length = buffer:len()
-    if length < 53 then return false end
+    if length < 38 then return false end
 
     local tokens = {"RaUdP", "RpUdP", "RrUdP"}
     local is_token = false

--- a/maritime-modules/heuristic.lua
+++ b/maritime-modules/heuristic.lua
@@ -104,7 +104,7 @@ end
 
 local function iec_61162_450_binary_heuristic_checker(buffer, pinfo, tree)
     local length = buffer:len()
-    if length < 38 then return false end
+    if length < 53 then return false end
 
     local tokens = {"RaUdP", "RpUdP", "RrUdP"}
     local is_token = false

--- a/maritime-modules/heuristic.lua
+++ b/maritime-modules/heuristic.lua
@@ -104,7 +104,7 @@ end
 
 local function iec_61162_450_binary_heuristic_checker(buffer, pinfo, tree)
     local length = buffer:len()
-    if length < 34 then return false end
+    if length < 38 then return false end
 
     local tokens = {"RaUdP", "RpUdP", "RrUdP"}
     local is_token = false

--- a/maritime-modules/knownids/sentences.lua
+++ b/maritime-modules/knownids/sentences.lua
@@ -52,6 +52,7 @@ local known_sentences = {
     RSA="Rudder Sensor Angle",
     RSD="RADAR System Data",
     RTE="Routes",
+    RRT="Report route transfer",
     SFI="Scanning Frequency Information",
     STN="Multiple Data ID",
     TDS="Trawl Door Spread Distance",

--- a/maritime-modules/proto/iec61162450binary.lua
+++ b/maritime-modules/proto/iec61162450binary.lua
@@ -10,43 +10,46 @@ BINARY_FILE_DESCRIPTOR = Proto("binary-file-descriptor", "Binary File Descriptor
 local fd_length = ProtoField.uint32("binary-file-descriptor.fd_length", "File descriptor Length")
 local file_length = ProtoField.uint32("binary-file-descriptor.file_length", "File Length")
 local stat_of_acquisition = ProtoField.uint16("binary-file-descriptor.stat_of_acquisition", "Status of acquisition")
-local device  = ProtoField.bytes("binary-file-descriptor.device", "Device")
-local channel = ProtoField.bytes("binary-file-descriptor.channel", "Channel")
+local ack_dest_port = ProtoField.uint16("binary-file-descriptor.ack_dest_port", "Ack Destination Port")
 local type_length = ProtoField.uint8("binary-file-descriptor.type_length", "Type Length")
 local data_type = ProtoField.string("binary-file-descriptor.data_type", "Data Type")
 local stat_and_info = ProtoField.string("binary-file-descriptor.stat_and_info", "Status and information text")
-BINARY_FILE_DESCRIPTOR.fields = {fd_length, file_length, stat_of_acquisition, device, channel, type_length, data_type, stat_and_info}
+BINARY_FILE_DESCRIPTOR.fields = {fd_length, file_length, stat_of_acquisition, ack_dest_port, type_length, data_type, stat_and_info}
 
 function BINARY_FILE_DESCRIPTOR.dissector(buffer, pinfo, tree)
     local fd_len = buffer(0, 4):uint()
     local type_len = buffer(12, 1):uint()
-    local stat_and_info_len = fd_len - type_len - 13
+    local status_len = buffer(13 + type_len, 2):uint()
 
     local subtree = tree:add(BINARY_FILE_DESCRIPTOR, buffer(), "IEC 61162-450 Binary file descriptor")
 
     subtree:add(fd_length, buffer(0, 4))
     subtree:add(file_length, buffer(4, 4))
     subtree:add(stat_of_acquisition, buffer(8, 2))
-    subtree:add(device, buffer(10, 1))
-    subtree:add(channel, buffer(11, 1))
+    subtree:add(ack_dest_port, buffer(10, 2))
     subtree:add(type_length, buffer(12, 1))
     subtree:add(data_type, buffer(13, type_len))
-    subtree:add(stat_and_info, buffer(13 + type_len, stat_and_info_len))
+    if status_len > 0 then
+        subtree:add(stat_and_info, buffer(15 + type_len, status_len))
+    end
 end
 IEC_61162_450_BINARY = Proto("iec-61162-450-binary", "IEC 61162-450 Binary File")
 
 local token = ProtoField.string("iec-61162-450-binary.token", "Token")
 local version = ProtoField.uint16("iec-61162-450-binary.version", "Version")
+local headerlength = ProtoField.uint16("iec-61162-450-binary.headerlength", "Header Length")
 local srcid = ProtoField.string("iec-61162-450-binary.srcid", "Source ID")
 local destid = ProtoField.string("iec-61162-450-binary.destid", "Destination ID")
 local mtype = ProtoField.uint16("iec-61162-450-binary.mtype", "Type")
 local blockid = ProtoField.uint32("iec-61162-450-binary.blockid", "Block ID")
 local seqnum = ProtoField.uint32("iec-61162-450-binary.seqnum", "Sequence Number")
 local maxseqnum = ProtoField.uint32("iec-61162-450-binary.maxseqnum", "Maximum Sequence Number")
+local device_f  = ProtoField.uint8("iec-61162-450-binary.device", "Device")
+local channel_f = ProtoField.uint8("iec-61162-450-binary.channel", "Channel")
 local firstpacket = ProtoField.framenum("iec-61162-450-binary.firstpacket", "First binary fragment (incl. binary file descriptor)", base.None, frametype.REQUEST)
 local prevpacket = ProtoField.framenum("iec-61162-450-binary.prevpacket", "Previous binary fragment", base.None, frametype.REQUEST)
 local nextpacket = ProtoField.framenum("iec-61162-450-binary.nextpacket", "Next binary fragment", base.None, frametype.RESPONSE)
-IEC_61162_450_BINARY.fields = {token, version, srcid, destid, mtype, blockid, seqnum, maxseqnum, firstpacket, prevpacket, nextpacket}
+IEC_61162_450_BINARY.fields = {token, version, headerlength, srcid, destid, mtype, blockid, seqnum, maxseqnum, device_f, channel_f, firstpacket, prevpacket, nextpacket}
 
 function IEC_61162_450_BINARY.dissector(buffer, pinfo, tree)
     local length = buffer:len()
@@ -56,14 +59,17 @@ function IEC_61162_450_BINARY.dissector(buffer, pinfo, tree)
 
     local subtree = tree:add(IEC_61162_450_BINARY, buffer(), "IEC 61162-450 Binary")
 
-    subtree:add(token, buffer(0,6))
-    subtree:add(version, buffer(6,2))
-    subtree:add(srcid, buffer(8,6))
-    subtree:add(destid, buffer(14,6))
-    subtree:add(mtype, buffer(20,2))
-    subtree:add(blockid, buffer(22,4))
-    subtree:add(seqnum, buffer(26,4))
-    subtree:add(maxseqnum, buffer(30,4))
+    subtree:add(token,        buffer(0,  6))
+    subtree:add(version,      buffer(6,  2))
+    subtree:add(headerlength, buffer(8,  2))
+    subtree:add(srcid,        buffer(10, 6))
+    subtree:add(destid,       buffer(16, 6))
+    subtree:add(mtype,        buffer(22, 2))
+    subtree:add(blockid,      buffer(24, 4))
+    subtree:add(seqnum,       buffer(28, 4))
+    subtree:add(maxseqnum,    buffer(32, 4))
+    subtree:add(device_f,     buffer(36, 1))
+    subtree:add(channel_f,    buffer(37, 1))
 
     local first_pack, prev_pack, next_pack = binarystream:get_binary_stream(buffer, pinfo)
     if first_pack ~= nil then
@@ -76,11 +82,11 @@ function IEC_61162_450_BINARY.dissector(buffer, pinfo, tree)
         subtree:add(nextpacket, next_pack)
     end
 
-    local mtype = buffer(20,2):uint()
-    local seqnum = buffer(26, 4):uint()
+    local mtype = buffer(22, 2):uint()
+    local seqnum = buffer(28, 4):uint()
     if seqnum == 1 then
         if mtype == 1 then
-            local subbuffer = buffer(34):tvb()
+            local subbuffer = buffer(38):tvb()
             BINARY_FILE_DESCRIPTOR.dissector(subbuffer, pinfo, subtree)
         end
     end


### PR DESCRIPTION
The dissector was implemented against Edition 1 of the standard. Edition 2 introduced breaking changes to the header and BFD layout that caused all fields after Version to be misaligned.

Header changes (Table 9):
- add HeaderLength field (WORD) at offset 8 — shifts all subsequent field offsets by +2
- move Device and Channel fields from BFD into the header (offsets 36, 37)
- update minimum valid packet length from 34 to 38 bytes in heuristic

Binary File Descriptor changes (Table 10):
- replace Device + Channel fields with AckDestPort (WORD) at offset 10
- parse StatusLength explicitly from the packet instead of inferring it

Update binarystream.lua reassembly offsets to match the new header layout.

Add RRT (Report route transfer) to the known NMEA sentence ID list per IEC 61162-1 / IEC 61174:2015 Annex T.2.